### PR TITLE
Streamline Internal API, and Fix :time-based Rolling Policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ a number of keys.
 
 ### Global Options
 
-- `:level`: Default logging level, any of `debug`, `info`, `warn`, `error`, `all`, `trace`, `off`.
-- `:external`: Do not try to configure logging, an external configuration has been supplied.
-- `:overrides`: Provide a map of namespace to level, overriding the provided default level.
+* `:level`: Default logging level
+  * any of `:debug`, `:info`, `:warn`, `:error`, `:all`, `:trace`, `:off`.
+* `:external`
+  * If it is `true`, do not try to configure logging. An external configuration is supplied.
+* `:overrides`
+  * Provide a map of namespace to level, overriding the provided default level.
 
 ### Console
 
@@ -98,7 +101,8 @@ As for `Files`, but do not assume a specific appender, expect it to be supplied 
 ## Example configuration map
 
 ```clojure
-{:console false
+{:level   :info
+ :console false
  :files ["/var/log/standard.log"
          {:file "/var/log/standard-json.log" :encoder :json}]
  :file {:file "/var/log/file.log" :encoder :json}
@@ -124,7 +128,9 @@ As for `Files`, but do not assume a specific appender, expect it to be supplied 
                                :max-index 5}
               :triggering-policy {:type :size-based
                                   :max-size 5120}
-              :file     "/var/log/rolling-file.log"}]}
+              :file     "/var/log/rolling-file.log"}]
+ :overrides  {"org.apache.http"      :debug
+              "org.apache.http.wire" :error}}
 ```
 
 ## Encoders

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ There is only one triggering policy, `:size-based`.
 
 {:appender :rolling-file
  :rolling-policy :fixed-window
- :triggering-policy {:type     :size-base
+ :triggering-policy {:type     :size-based
                      ;; Refer to
                      ;; http://logback.qos.ch/manual/appenders.html#SizeBasedTriggeringPolicy
                      :max-size 51200}} ; 51200 bytes

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ As for `Files`, but do not assume a specific appender, expect it to be supplied 
 
 The following encoders are currently supported:
 
-- `PatternLayoutEncoder`: Using a default pattern of `"%p [%d] %t - %c %m%n"`. Use `:encoder :pattern`.
+- `PatternLayoutEncoder`: Using a default pattern of `"%p [%d] %t - %c%n%m%n"`. Use `:encoder :pattern`.
 - `LogstashEncoder`: If you wish to format messages for logstash. Use `:encoder :json`.
 
 ## Appenders

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Unilog provides a simple and somewhat opiniated way of configuring
 ## Coordinates
 
 ```clojure
-[spootnik/unilog "0.7.4"]
+[spootnik/unilog "0.7.5"]
 ```
 
 ## Usage
@@ -69,17 +69,23 @@ a number of keys.
 
 If the `:console` key is present in the configuration map, it may be any of:
 
-- `false`: Do not log to the console.
-- `true`: Log to the console, using a pattern encoder and the default pattern.
-- A string: Log to the console, using a pattern encoder and the supplied pattern string.
-- A map: Log to the console, other attributes are taken from the map. For instance: `{:console {:encoder :json}}`.
+* `false`
+  * Do not log to the console.
+* `true`
+  * Log to the console, using a pattern encoder and the default pattern.
+* A string
+  * Log to the console, using a pattern encoder and the supplied pattern string.
+* A map
+  * Log to the console, other attributes are taken from the map.
+  * For instance: `{:console {:encoder :json}}`.
 
 ### File
 
 If the `:file` key is present in the configuration map, it may be any of:
 
-- A string: Log to the provided file, using a pattern encoder and the default pattern.
-- A map: Log to a file, taking configuration attributes from the map. For instance: `{:file {:file "/var/log/foo.log" :encoder :json}}`
+* A string: Log to the provided file, using a pattern encoder and the default pattern.
+* A map: Log to a file, taking configuration attributes from the map.
+  * For instance: `{:file {:file "/var/log/foo.log" :encoder :json}}`
 
 ### Files
 
@@ -99,16 +105,20 @@ As for `Files`, but do not assume a specific appender, expect it to be supplied 
  :appenders [{:appender :file
               :encoder  :json
               :file     "/var/log/other-json.log"}
+
              {:appender :file
               :encoder  :pattern
               :pattern  "%p [%d] %t - %c %m%n"
               :file     "/var/log/other-pattern.log"}
+
              {:appender :rolling-file
               :file     "/var/log/rolling-file.log"}
+
              {:appender :rolling-file
               :rolling-policy :fixed-window
               :triggering-policy :size-based
               :file     "/var/log/rolling-file.log"}
+
              {:appender :rolling-file
               :rolling-policy {:type :fixed-window
                                :max-index 5}
@@ -119,23 +129,22 @@ As for `Files`, but do not assume a specific appender, expect it to be supplied 
 
 ## Encoders
 
-The following encoders are currently supported in `:appenders`
+You could specify encoder arguments in some appenders. Not every appender supports encoders.
+The following encoders are currently supported in `:appenders`.
 
-`PatternLayoutEncoder` uses a default pattern of `"%p [%d] %t - %c%n%m%n"`
+`PatternLayoutEncoder` uses a default pattern of `"%p [%d] %t - %c%n%m%n"`.
 
 ```clojure
 {:appender :file
  :file     "/var/log/file.log"
  ;; PatternLayoutEncoder
- ;; Without :pattern, the default pattern is used.
- :encoder  :pattern
- }
+ ;; Without :pattern argument in an appender config, the default pattern is used.
+ :encoder  :pattern}
 
 {:appender :file
  :file     "/var/log/file2.log"
  :encoder  :pattern
- :pattern  "%p [%d] %t - %c%n%m%n"
- }
+ :pattern  "%p [%d] %t - %c%n%m%n"}
 ```
 
 `LogstashEncoder` formats messages for logstash.
@@ -144,8 +153,7 @@ The following encoders are currently supported in `:appenders`
 {:appender :file
  :file     "/var/log/file3.log"
  ;; LogstashEncoder
- :encoder  :json
- }
+ :encoder  :json}
 ```
 
 ## Appenders
@@ -154,21 +162,48 @@ The following appenders are currently supported:
 
 ### `:console` appender
 
-It has no further arguments.
+* Optional Arguments
+  * `:encoder`
+  * `:pattern`
 
 ```clojure
 {:appender :console}
+
+{:appender :console
+ :encoder  :pattern}
+
+{:appender :console
+ :encoder  :pattern
+ :pattern  "%p [%d] %t - %c%n%m%n"}
+
+{:appender :console
+ :encoder  :json}
 ```
 
 ### `:file` appender
 
 * Mandatory Arguments
   * `:file`
+* Optional Arguments
+  * `:encoder`
+  * `:pattern`
 
 ```clojure
 {:appender :file
+ :file     "/var/log/file.log"}
+
+{:appender :file
  :file     "/var/log/file.log"
- }
+ :encoder  :pattern}
+
+{:appender :file
+ :file     "/var/log/file.log"
+ :encoder  :pattern
+ :pattern  "%p [%d] %t - %c%n%m%n"}
+
+{:appender :file
+ :file     "/var/log/file.log"
+ :encoder  :json}
 ```
 
 ### `:rolling-file` appender
@@ -178,6 +213,8 @@ It has no further arguments.
 * Optional Arguments
   * `:rolling-policy`
   * `:triggering-policy`
+  * `:encoder`
+  * `:pattern`
 
 There are two rolling policies.
 
@@ -190,31 +227,31 @@ Don't use a triggering policy with `:time-based` rolling policy since `:time-bas
 You can specify a rolling policy by the keyword.
 
 ```clojure
-{:appender :rolling-file
+{:appender       :rolling-file
  :rolling-policy :fixed-window
- :file     "/var/log/rolling-file.log"
- }
+ :file           "/var/log/rolling-file.log"
+ :encoder        :pattern}
 
 {:appaneder :rolling-file
  :rolling-policy :time-based
- :file     "/var/log/rolling-file2.log"
- }
+ :file           "/var/log/rolling-file2.log"
+ :encoder        :pattern
+ :pattern        "%p [%d] %t - %c%n%m%n"}
 ```
 
 If you want to specify arguments for a rolling policy, you can pass a map to `:rolling-policy` as below. every argument to a rolling policy except `:type` is optional.
 
 ```clojure
 {:appender :rolling-file
- :file "rolling-file.log"
+ :file           "rolling-file.log"
  :rolling-policy {:type      :fixed-window
                   :min-index 1
                   :max-index 5
                   ;; :pattern combines with :file to make the name of a rolled log file.
                   ;; For example, "rolling-file.log.%i.gz"
                   ;; %i is index.
-                  :pattern  ".%i.gz"
-                  }
- }
+                  :pattern  ".%i.gz"}
+ :encoder        :json}
 
 {:appender :rolling-file
  :file "rolling-file2.log"
@@ -230,9 +267,9 @@ If you want to specify arguments for a rolling policy, you can pass a map to `:r
                   ;; for elaborate description of :max-size
                   :max-size    51200 ; bytes
                   ;; :pattern combines with :file
-                  :pattern    ".%d{yyyy-MM-dd}.%i"
-                  }
- }
+                  :pattern    ".%d{yyyy-MM-dd}.%i"}
+ :encoder :pattern
+ :pattern "%p [%d] %t - %c%n%m%n"}
 ```
 
 There is only one triggering policy, `:size-based`.
@@ -243,17 +280,14 @@ There is only one triggering policy, `:size-based`.
  ;; If you don't pass any argument to :size-based triggering policy, it triggers a rollover
  ;; when a log file grow beyond SizeBasedTriggeringPolicy/DEFAULT_MAX_FILE_SIZE.
  :triggering-policy :size-based
- :file          "rolling-file.log"
- }
+ :file          "rolling-file.log"}
 
 {:appender :rolling-file
  :rolling-policy :fixed-window
  :triggering-policy {:type     :size-base
                      ;; Refer to
                      ;; http://logback.qos.ch/manual/appenders.html#SizeBasedTriggeringPolicy
-                     :max-size 51200 ; bytes
-                     }
- }
+                     :max-size 51200}} ; 51200 bytes
 ```
 
 ### `:socket` appender
@@ -262,7 +296,7 @@ There is only one triggering policy, `:size-based`.
   * `:remote-host`
   * `:port`
   * `:queue-size`
-  * `reconnection-delay`
+  * `:reconnection-delay`
   * `:event-delay-limit`
 
 ```clojure
@@ -271,8 +305,7 @@ There is only one triggering policy, `:size-based`.
  :port                2004
  :queue-size          500
  :reconnection-delay "10 seconds"
- :event-delay-limit  "10 seconds"
- }
+ :event-delay-limit  "10 seconds"}
 ```
 
 ### `:syslog` appender
@@ -284,8 +317,7 @@ There is only one triggering policy, `:size-based`.
 ```clojure
 {:appender :syslog
  :host    "localhost"
- :port     514
- }
+ :port     514}
 ```
 
 ## Extending

--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ If you want to specify arguments for a rolling policy, you can pass a map to `:r
                   ;; for elaborate description of :max-size
                   :max-size    51200 ; bytes
                   ;; :pattern combines with :file
+                  ;; The rolling period is defined by :pattern.
+                  ;; Refer to http://logback.qos.ch/manual/appenders.html#tbrpFileNamePattern
                   :pattern    ".%d{yyyy-MM-dd}.%i"}
  :encoder :pattern
  :pattern "%p [%d] %t - %c%n%m%n"}

--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -41,7 +41,7 @@
 
 (def default-pattern
   "Default pattern for PatternLayoutEncoder"
-  "%p [%d] %t - %c %m%n")
+  "%p [%d] %t - %c%n%m%n")
 
 (def default-encoder
   "Default encoder and pattern configuration"

--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -32,13 +32,13 @@
 
 (def levels
   "Logging level names to log4j level association"
-  {"debug" Level/DEBUG
-   "info"  Level/INFO
-   "warn"  Level/WARN
-   "error" Level/ERROR
-   "all"   Level/ALL
-   "trace" Level/TRACE
-   "off"   Level/OFF})
+  {:debug Level/DEBUG
+   :info  Level/INFO
+   :warn  Level/WARN
+   :error Level/ERROR
+   :all   Level/ALL
+   :trace Level/TRACE
+   :off   Level/OFF})
 
 (def default-pattern
   "Default pattern for PatternLayoutEncoder"
@@ -319,15 +319,16 @@ example:
   "
   ([{:keys [external level overrides] :as config}]
    (when-not external
-     (let [level   (get levels (some-> level name) Level/INFO)
-           root    (LoggerFactory/getLogger Logger/ROOT_LOGGER_NAME)
-           context (LoggerFactory/getILoggerFactory)
-           configs (->> (merge {:console true} config)
-                        (map appender-config)
-                        (flatten)
-                        (remove nil?)
-                        (map build-appender)
-                        (map build-encoder))]
+     (let [get-level #(get levels % Level/INFO)
+           level     (get-level level)
+           root      (LoggerFactory/getLogger Logger/ROOT_LOGGER_NAME)
+           context   (LoggerFactory/getILoggerFactory)
+           configs   (->> (merge {:console true} config)
+                          (map appender-config)
+                          (flatten)
+                          (remove nil?)
+                          (map build-appender)
+                          (map build-encoder))]
 
        (.detachAndStopAllAppenders root)
 
@@ -342,7 +343,7 @@ example:
        (.setLevel root level)
        (doseq [[logger level] overrides
                :let [logger (LoggerFactory/getLogger (name logger))
-                     level  (get levels level Level/INFO)]]
+                     level  (get-level level)]]
          (.setLevel logger level))
        root)))
   ([]

--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -150,8 +150,10 @@
         pattern (if pattern
                   pattern
                   (if max-size
-                    ".%d{yyyy-MM-dd}.%i.gz"
-                    ".%d{yyyy-MM-dd}.gz"))]
+                    ;; TimeBasedRollingPolicy has a compression issue
+                    ;; http://jira.qos.ch/browse/LOGBACK-992
+                    ".%d{yyyy-MM-dd}.%i"
+                    ".%d{yyyy-MM-dd}"))]
     (if max-size
       (->> (doto (SizeAndTimeBasedFNATP.)
              (.setMaxFileSize (str max-size)))

--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -142,16 +142,14 @@
     (.setMinIndex (int min-index))
     (.setMaxIndex (int max-index))
     (.setParent parent)
-    (.setContext (.getContext parent))
-    (.start)))
+    (.setContext (.getContext parent))))
 
 (defmethod build-rolling-policy :time-based
   [{:keys [file pattern parent] :or {pattern ".%d{yyyy-MM-dd}.gz"}}]
   (doto (TimeBasedRollingPolicy.)
     (.setFileNamePattern (str file pattern))
     (.setParent parent)
-    (.setContext (.getContext parent))
-    (.start)))
+    (.setContext (.getContext parent))))
 
 ;;
 ;; Open dispatch to build a triggering policy for rolling files
@@ -225,23 +223,24 @@
                (.setContext context)
                (.setEncoder encoder)
                (.setRollingPolicy
-                (build-rolling-policy
-                 (merge
-                  {:file file}
-                  (cond
-                    (keyword? rolling-policy)
-                    {:type rolling-policy}
+                (doto (build-rolling-policy
+                       (merge
+                        {:file file}
+                        (cond
+                          (keyword? rolling-policy)
+                          {:type rolling-policy}
 
-                    (string? rolling-policy)
-                    {:type (keyword rolling-policy)}
+                          (string? rolling-policy)
+                          {:type (keyword rolling-policy)}
 
-                    (map? rolling-policy)
-                    (update-in rolling-policy [:type] keyword)
+                          (map? rolling-policy)
+                          (update-in rolling-policy [:type] keyword)
 
-                    :else
-                    (throw (ex-info "invalid rolling policy"
-                                    {:config rolling-policy})))
-                  {:parent appender})))
+                          :else
+                          (throw (ex-info "invalid rolling policy"
+                                          {:config rolling-policy})))
+                        {:parent appender}))
+                  (.start)))
                (.setTriggeringPolicy
                 (build-triggering-policy
                  (merge {:file file}


### PR DESCRIPTION
* Since log message starts on the same line as log metadata, it is difficult to read logs with bare eyes. By inserting a newline between log metadata and log message, it becomes easier to read logs.
* In :rolling-file build-appender, :time-based rolling policy should disable any triggering policy specified in config because TimeBasedRollingPolicy is its own triggering policy.
* :time-based build-rolling-policy now has two new options.
  * `:max-history` sets the number of periods(not of log files) to keep log files
  * When a file reaches `:max-size` which is an optional option, it is rolled.
  * Caveat : No matter how many files are rolled due to `:max-size` option, log files are kept for `:max-history` periods(hour, day, week, month, ...).
* build-appender methods for :syslog and :rolling-file had to be separated from encoder and context. If I don't specify an encoder for :syslog and :rolling-file appenders in config, no encoder was assigned to the appenders because build-appender methods for those appenders made a function that generates an appender, and the default build-encoder method assumed the encoders were already java class instances. Now, start-logging! inserts encoder into appender, and start-appender! was separated from build-appender to insert the context into appenders and their components and to start them in proper sequences. `:rolling-file` appender is sensitive to sequence of initializing operations which is handled by start-appender!.
* Every log level is a keyword now because it is more idiomatic.
* Explain appenders and encoders in detail in README so that users can learn configuration options without reading source code.