### PR TITLE
Add :fatal log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ a number of keys.
 ### Global Options
 
 * `:level`: Default logging level
-  * any of `:debug`, `:info`, `:warn`, `:error`, `:all`, `:trace`, `:off`.
+  * any of `:all`, `:trace`, `:debug`, `:info`, `:warn`, `:error`, `:fatal`, `:off`
 * `:external`
   * If it is `true`, do not try to configure logging. An external configuration is supplied.
 * `:overrides`

--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -32,12 +32,13 @@
 
 (def levels
   "Logging level names to log4j level association"
-  {:debug Level/DEBUG
+  {:all   Level/ALL
+   :trace Level/TRACE
+   :debug Level/DEBUG
    :info  Level/INFO
    :warn  Level/WARN
    :error Level/ERROR
-   :all   Level/ALL
-   :trace Level/TRACE
+   :fatal Level/FATAL
    :off   Level/OFF})
 
 (def default-pattern


### PR DESCRIPTION
Log levels are ordered in the decreasing order of verbosity.
Refer to http://www.slf4j.org/apidocs/org/apache/log4j/Level.html