### PR TITLE
Fix policy as a map causing RuntimeException

### DIFF
--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -232,7 +232,7 @@
                         (cond
                           (keyword? policy) {:type policy}
                           (string? policy) {:type policy}
-                          (map? policy) (update policy :type keyword)
+                          (map? policy) (assoc policy :type keyword)
                           :else
                           (throw (ex-info (format "invalid %s policy" type)
                                           {:config policy}))))


### PR DESCRIPTION
Exception:

    Caused by: java.lang.RuntimeException: Unable to resolve symbol: update in this context