### PR TITLE
Fix macro namespacing for with-context.

### DIFF
--- a/src/unilog/context.clj
+++ b/src/unilog/context.clj
@@ -22,5 +22,5 @@
          (push-context k# v#))
        ~@body
        (finally
-         (doseq [[k# _] ~ctx]
+         (doseq [[k# _#] ~ctx]
            (pull-context k#))))))


### PR DESCRIPTION
1.8 fixes a compiler bug which allowed some un-namespaced uses of _ in macros to slip through.

http://dev.clojure.org/jira/browse/CLJ-1778