### PR TITLE
Add j.u.l. bridge

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,13 +3,13 @@
   :url "https://github.com/pyr/unilog"
   :license {:name "MIT License"
             :url "https://github.com/pyr/unilog/tree/master/LICENSE"}
-  :plugins [[codox "0.8.10"]]
+  :plugins [[codox "0.9.6"]]
   :codox {:defaults {:doc/format :markdown}}
   :dependencies [[org.clojure/clojure                           "1.8.0"]
-                 [net.logstash.logback/logstash-logback-encoder "4.2"]
-                 [org.slf4j/slf4j-api                           "1.7.12"]
-                 [org.slf4j/log4j-over-slf4j                    "1.7.12"]
-                 [org.slf4j/jul-to-slf4j                        "1.7.12"]
-                 [ch.qos.logback/logback-classic                "1.1.3"]
-                 [ch.qos.logback/logback-core                   "1.1.3"]]
+                 [net.logstash.logback/logstash-logback-encoder "4.7"]
+                 [org.slf4j/slf4j-api                           "1.7.21"]
+                 [org.slf4j/log4j-over-slf4j                    "1.7.21"]
+                 [org.slf4j/jul-to-slf4j                        "1.7.21"]
+                 [ch.qos.logback/logback-classic                "1.1.7"]
+                 [ch.qos.logback/logback-core                   "1.1.7"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.logging "0.3.1"]]}})

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                  [net.logstash.logback/logstash-logback-encoder "4.2"]
                  [org.slf4j/slf4j-api                           "1.7.12"]
                  [org.slf4j/log4j-over-slf4j                    "1.7.12"]
+                 [org.slf4j/jul-to-slf4j                        "1.7.12"]
                  [ch.qos.logback/logback-classic                "1.1.3"]
                  [ch.qos.logback/logback-core                   "1.1.3"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.logging "0.3.1"]]}})

--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -10,6 +10,7 @@
    Two extension mechanism are provided to add support for more appenders and encoders,
    see `build-appender` and `build-encoder` respectively"
   (:import org.slf4j.LoggerFactory
+           org.slf4j.bridge.SLF4JBridgeHandler
            ch.qos.logback.classic.net.SocketAppender
            ch.qos.logback.classic.encoder.PatternLayoutEncoder
            ch.qos.logback.classic.Logger
@@ -329,6 +330,8 @@ example:
    (let [config (merge default-configuration raw-config)
          {:keys [external level overrides]} config]
      (when-not external
+       (SLF4JBridgeHandler/removeHandlersForRootLogger)
+       (SLF4JBridgeHandler/install)
        (let [get-level #(get levels (some-> % keyword) Level/INFO)
              level     (get-level level)
              root      (LoggerFactory/getLogger Logger/ROOT_LOGGER_NAME)


### PR DESCRIPTION
This changes `start-logging!` to automatically install the `java.util.logging` bridge. It also upgrade the dependencies to the latest.

Closes #11.