### PR TITLE
Stop relying on logstash-logback-encoder for JSON encoding

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
   :codox {:source-uri "https://github.com/pyr/unilog/blob/{version}/{filepath}#L{line}"
           :metadata   {:doc/format :markdown}}
   :dependencies [[org.clojure/clojure                           "1.8.0"]
-                 [net.logstash.logback/logstash-logback-encoder "4.8"]
+                 [cheshire                                      "5.7.0"]
+                 [clj-time                                      "0.13.0"]
                  [org.slf4j/slf4j-api                           "1.7.22"]
                  [org.slf4j/log4j-over-slf4j                    "1.7.22"]
                  [org.slf4j/jul-to-slf4j                        "1.7.22"]

--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -33,8 +33,8 @@
            ch.qos.logback.core.rolling.RollingFileAppender
            ch.qos.logback.core.util.Duration
            ch.qos.logback.core.util.FileSize
-           ch.qos.logback.core.net.SyslogOutputStream
-           net.logstash.logback.encoder.LogstashEncoder))
+           ch.qos.logback.core.net.SyslogOutputStream)
+  (:require [unilog.encoder.json :as json]))
 
 ;; Configuration constants
 ;; =======================
@@ -133,7 +133,7 @@
 
 (defmethod build-encoder :json
   [config]
-  (assoc config :encoder (LogstashEncoder.)))
+  (assoc config :encoder (json/make-encoder)))
 
 (defmethod build-encoder :default
   [{:keys [appender] :as config}]

--- a/src/unilog/encoder/json.clj
+++ b/src/unilog/encoder/json.clj
@@ -1,0 +1,39 @@
+(ns unilog.encoder.json
+  (:import ch.qos.logback.classic.spi.LoggingEvent
+           ch.qos.logback.core.encoder.EncoderBase)
+  (:require [cheshire.core :refer [generate-string]]
+            [clj-time.coerce :refer [from-long]]
+            [clj-time.format :refer [unparse formatters]
+             ]))
+
+(defn- ^"[B" str-bytes
+  [^String s ^String sep]
+  (.getBytes (str s sep)))
+
+(def header-bytes (byte-array 0))
+(def footer-bytes (byte-array 0))
+
+(defn iso8601
+  [date]
+  (unparse (:date-time formatters) (from-long date)))
+
+(defn format-event
+  [^LoggingEvent ev]
+  (merge
+   (into {} (.getMDCPropertyMap ev))
+   {"@version"   1
+    "@timestamp" (iso8601 (.getTimeStamp ev))
+    :message     (.getMessage ev)
+    :logger-name (.getLoggerName ev)
+    :thread-name (.getThreadName ev)
+    :level       (-> ev .getLevel .levelStr)}))
+
+(defn make-encoder
+  []
+  (proxy [EncoderBase] []
+    (encode      [e] (str-bytes (generate-string (format-event e)) "\n"))
+    (headerBytes []  header-bytes)
+    (footerBytes []  footer-bytes)
+    (isStarted   []  true)
+    (start       []) ;; no-op
+    (stop        []))) ;; no-op

--- a/test/unilog/config_test.clj
+++ b/test/unilog/config_test.clj
@@ -7,14 +7,26 @@
 
   (testing "Text logging to console"
     (start-logging! {:level :info})
-    (is (nil? (debug "debug")))
-    (is (nil? (info "info")))
-    (is (nil? (warn "warn")))
-    (is (nil? (error "error"))))
+    (is (nil? (debug "default config")))
+    (is (nil? (info "default config")))
+    (is (nil? (warn "default config")))
+    (is (nil? (error "default config"))))
+
+  (testing "Text logging to console, through `appenders` key"
+    (start-logging! {:level     :info
+                     :console   false
+                     :appenders [{:appender :console}]})
+    (is (nil? (debug "text config")))
+    (is (nil? (info "text config")))
+    (is (nil? (warn "text config")))
+    (is (nil? (error "text config"))))
 
   (testing "JSON logging to console"
-    (start-logging! {:level :info :appenders [{:appender :console :encoder :json}]})
-    (is (nil? (debug "debug")))
-    (is (nil? (info "info")))
-    (is (nil? (warn "warn")))
-    (is (nil? (error "error"))))  )
+    (start-logging! {:level     :info
+                     :console   false
+                     :appenders [{:appender :console
+                                  :encoder  :json}]})
+    (is (nil? (debug "JSON config")))
+    (is (nil? (info "JSON config")))
+    (is (nil? (warn "JSON config")))
+    (is (nil? (error "JSON config"))))  )


### PR DESCRIPTION
Provides a fix for #15, but the approach is debatable.
@codahale I would like your thoughts/feedback on two things:

- Whether this breaks your logs or not.
- Unrelated, I'm also debating adding a dep to clojure 1.9 for future versions to take advantage of spec, will that be a dealbreaker for you?