### PR TITLE
add missing context for time-based rolling policy

### DIFF
--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -279,9 +279,11 @@
   [^RollingFileAppender appender ^LoggerContext context]
   ;; The order of operations is important. If you change it, errors will occur.
   (.setContext appender context)
-  (doto ^RollingPolicy (.getRollingPolicy appender)
-    (.setParent appender)
-    (.start))
+  (let [^RollingPolicy rp (.getRollingPolicy appender)]
+    (.setParent rp  appender)
+    (when (instance? ContextAware rp)
+      (.setContext ^ContextAware rp context))
+    (.start rp))
   (when-let [tp ^TriggeringPolicy (.getTriggeringPolicy appender)]
     ;; Since TimeBasedRollingPolicy can serve as a triggering policy,
     ;; start triggering policy only if it is not started already.


### PR DESCRIPTION
Otherwise we'd get logs like this: 
`LOGBACK: No context given for c.q.l.core.rolling.TimeBasedRollingPolicy@1781836524`
followed by an exception `Exception in thread "main" java.lang.IllegalStateException: FileNamePattern [/var/logs/shore-web.log.{yyyy-MM-dd}.%i] does not contain a valid DateToken, compiling:(/tmp/form-init5797828860007935541.clj:1:73)`

related to #17