### PR TITLE
Upgrade to logback 1.2.x.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,12 +7,12 @@
   :codox {:source-uri "https://github.com/pyr/unilog/blob/{version}/{filepath}#L{line}"
           :metadata   {:doc/format :markdown}}
   :dependencies [[org.clojure/clojure                           "1.8.0"]
-                 [net.logstash.logback/logstash-logback-encoder "4.8"]
-                 [org.slf4j/slf4j-api                           "1.7.22"]
-                 [org.slf4j/log4j-over-slf4j                    "1.7.22"]
-                 [org.slf4j/jul-to-slf4j                        "1.7.22"]
-                 [ch.qos.logback/logback-classic                "1.1.8"]
-                 [ch.qos.logback/logback-core                   "1.1.8"]]
+                 [net.logstash.logback/logstash-logback-encoder "4.9"]
+                 [org.slf4j/slf4j-api                           "1.7.24"]
+                 [org.slf4j/log4j-over-slf4j                    "1.7.24"]
+                 [org.slf4j/jul-to-slf4j                        "1.7.24"]
+                 [ch.qos.logback/logback-classic                "1.2.1"]
+                 [ch.qos.logback/logback-core                   "1.2.1"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.logging "0.3.1"]
                                   [cheshire                  "5.7.0"]
                                   [clj-time                  "0.13.0"]]


### PR DESCRIPTION
Upgrade `logback` to 1.2.1, `logstack-logback-encoder` to 4.9.

Passes tests in my application and is verified to work.