### PR TITLE
Adding filter support to all appenders implementing UnsynchronizedAppenderBase

### DIFF
--- a/src/unilog/config.clj
+++ b/src/unilog/config.clj
@@ -205,22 +205,6 @@
 ;; Open dispatch method to build appenders
 ;; =======================================
 
-(def result-mapping {:accept  FilterReply/ACCEPT
-                     :deny    FilterReply/DENY
-                     :neutral FilterReply/NEUTRAL})
-
-(defn make-log-property-filter
-  [field pred match no-match]
-  (let [match-enum    (result-mapping match)
-        no-match-enum (result-mapping no-match)]
-    (proxy [Filter] []
-      (decide [^ILoggingEvent event]
-        (let [mdc (.getMDCPropertyMap event)
-              v   (.get mdc (name field))]
-          (if (pred v)
-            match-enum
-            no-match-enum))))))
-
 (defmulti build-appender
   "Given a prepared configuration map, associate a prepared appender
   to the `:appender` key."
@@ -287,6 +271,24 @@
 (defmethod build-appender :default
   [val]
   (throw (ex-info "invalid log appender configuration" {:config val})))
+
+;;; build-filters
+;;; =======================================
+(def result-mapping {:accept  FilterReply/ACCEPT
+                     :deny    FilterReply/DENY
+                     :neutral FilterReply/NEUTRAL})
+
+(defn make-log-property-filter
+  [field pred match no-match]
+  (let [match-enum    (result-mapping match)
+        no-match-enum (result-mapping no-match)]
+    (proxy [Filter] []
+      (decide [^ILoggingEvent event]
+        (let [mdc (.getMDCPropertyMap event)
+              v   (.get mdc (name field))]
+          (if (pred v)
+            match-enum
+            no-match-enum))))))
 
 (defn build-filters
   [config]


### PR DESCRIPTION
Hi,

I'm not sure how to implement filter support as an extension on my side. The way I did it was to implement the `build-appender` and the `start-appender!` function for every type of appender I want to use. I feel like adding it to the library makes it simpler.

Would you be interested in that PR ? I could also add the filter instantiation in the `build-appender` method if you prefer.

What do you think ?