### PR TITLE
bug: fix repeated context keys removal

### DIFF
--- a/test/unilog/context_test.clj
+++ b/test/unilog/context_test.clj
@@ -1,0 +1,13 @@
+(ns unilog.context-test
+  (:require [unilog.context        :refer [with-context]]
+            [clojure.test          :refer [deftest is testing]]))
+
+(deftest context-is-stacked
+  (testing "Context stacking works as expected"
+    (with-context {"a" "1"}
+      (is (= "1" (get (org.slf4j.MDC/getCopyOfContextMap) "a")))
+      (with-context {:a 2}
+        (is (= "2" (get (org.slf4j.MDC/getCopyOfContextMap) "a"))))
+      (is (= "1" (get (org.slf4j.MDC/getCopyOfContextMap) "a"))))))
+  
+  


### PR DESCRIPTION
When two expressions use `with-context` with same keys but different values, the first to finish will remove the keys used by the other one. If the 2nd execution happens on the same thread, its keys will no longer be there.

Example:

```
;; execution 1
(with-context {:a 1}
   (log "start")
   (with-context {:a 2}
     (log "middle"))
   (log "end")) ;; will lose :a key
```