### PR TITLE
Upgrade logback to 1.2.8 for security issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def slf4j-version "1.7.32")
-(def logback-version "1.2.6")
+(def logback-version "1.2.8")
 
 (defproject spootnik/unilog "0.7.29-SNAPSHOT"
   :description "logging should be easy!"


### PR DESCRIPTION
logback < 1.2.8 has a (low priority) security issue.
See https://jira.qos.ch/browse/LOGBACK-1591