### PR TITLE
feat: allow configuring different patterns per logger

### DIFF
--- a/src/unilog/encoders.clj
+++ b/src/unilog/encoders.clj
@@ -1,0 +1,85 @@
+(ns unilog.encoders
+  (:import [ch.qos.logback.classic.encoder PatternLayoutEncoder]
+           [ch.qos.logback.classic.spi ILoggingEvent]
+           [ch.qos.logback.core Layout]
+           [ch.qos.logback.classic Logger]
+           [java.util Comparator]
+           [net.logstash.logback.encoder.org.apache.commons.lang3 StringUtils]))
+
+(defrecord LoggerEncoder [logger pattern encoder])
+
+(defn- make-encoder
+  "Make an encoder for the given params"
+  [logger pattern output-pattern-as-header]
+  (let [encoder (doto (PatternLayoutEncoder.)
+                  (.setPattern pattern)
+                  (.setOutputPatternAsHeader output-pattern-as-header))]
+    (->LoggerEncoder logger pattern encoder)))
+
+(defn- make-comparator
+  "Makes a `LoggerEncoder` comparator that puts the best match for a given `logger-name` first.
+  Uses the `logger` field to compare against `logger-name`."
+  [^String logger-name]
+  (reify Comparator
+    (compare [this encoder1 encoder2]
+      ;; remove the dots
+      ;; compare longest prefix
+      ;; return best match
+      (let [logger   (.replaceAll logger-name "\\." "")
+            e1logger (.replaceAll ^String (-> encoder1 :logger name) "\\." "")
+            e2logger (.replaceAll ^String (-> encoder2 :logger name) "\\." "")
+            o2match  (.length (StringUtils/getCommonPrefix (into-array String [e2logger logger])))
+            o1match  (.length (StringUtils/getCommonPrefix (into-array String [e1logger logger])))
+            ;; match is hierarchical, so we want the shortest one
+            ;; if some encoders have the same prefix (eg: logger-name is 'com.exoscale'
+            ;; and we have 'com.exoscale.blah' and 'com.exoscale.blah.c' we want the shortest one
+            o2Rem    (- (.length e2logger) o2match)
+            o1Rem    (- (.length e1logger) o1match)
+            diff     (- o2match o1match)]
+
+        (if (zero? diff)
+          (- o1Rem o2Rem)
+          diff)))))
+
+(defn- closest-match
+  "Find the closest encoder for the give `logger-name` and coll of `encoder`s.
+  Fallback to `root-layout` if none found"
+  ^Layout [logger-name encoders root-layout]
+  (if (or (.equalsIgnoreCase Logger/ROOT_LOGGER_NAME logger-name)
+          (empty? encoders))
+    root-layout
+    (let [encoder (->> encoders
+                       (sort (make-comparator logger-name))
+                       (first))]
+      (.getLayout ^PatternLayoutEncoder (:encoder encoder)))))
+
+(defn make-multilayout-encoder
+  "Create a custom PatternLayoutEncoder that can support multiple layouts per logger.
+  - `root-pattern` is a String
+  - `logger-patterns` is a map of `{logger pattern}`"
+  [root-pattern logger-patterns]
+  (let [layouts  (atom {})
+        encoders (for [kv logger-patterns
+                       :let [[logger root-pattern] kv]]
+                   (make-encoder logger root-pattern false))]
+    (proxy [PatternLayoutEncoder] []
+      (start []
+        (.setPattern ^PatternLayoutEncoder this root-pattern)
+        (run! #(do
+                 (.setContext ^PatternLayoutEncoder (:encoder %) (.getContext ^PatternLayoutEncoder this))
+                 (.start ^PatternLayoutEncoder (:encoder %)))
+               encoders)
+        (proxy-super start))
+      (encode [^ILoggingEvent event]
+        (let [logger-name    (.getLoggerName event)
+              root-layout    (.getLayout ^PatternLayoutEncoder this)
+              ;; cache the closest layout for a given logger name
+              ^Layout layout (get @layouts logger-name
+                                  (let [match (closest-match logger-name encoders root-layout)]
+                                    (swap! layouts assoc logger-name match)
+                                    match))
+              ^String txt    (.doLayout layout event)
+              charset        (.getCharset ^PatternLayoutEncoder this)]
+          (if (nil? charset)
+            (.getBytes txt)
+            (.getBytes txt charset)))))))

--- a/test/nsexample.clj
+++ b/test/nsexample.clj
@@ -1,0 +1,13 @@
+(ns nsexample
+  "Test ns to check different loggers"
+  (:require [clojure.tools.logging :as log]))
+
+(defn info
+  ([msg] (log/info msg))
+  ([e msg] (log/info e msg)))
+(defn warn
+  ([msg] (log/warn msg))
+  ([e msg] (log/warn e msg)))
+(defn error
+  ([msg] (log/error msg))
+  ([e msg] (log/error e msg)))

--- a/test/unilog/config_override_test.clj
+++ b/test/unilog/config_override_test.clj
@@ -3,7 +3,11 @@
             [clojure.test :refer [deftest is testing]]
             [clojure.tools.logging :refer [debug info warn error]]
             [unilog.testns :as testns]
-            [clojure.string :as str]))
+            [unilog.testns2 :as testns2]
+            [nsexample :as nsexample]
+            [clojure.string :as str])
+  (:import [java.io File]
+           [java.nio.file Files StandardOpenOption]))
 
 (defn- temp-file
   "Temp file which gets deleted when the JVM stops"
@@ -15,34 +19,57 @@
   (->> (str/split (slurp path) #"\n")
        (filter #(not (zero? (count %))))))
 
+(defn truncate [^File f]
+  (Files/write (.toPath f) (byte-array 0) (into-array StandardOpenOption [StandardOpenOption/TRUNCATE_EXISTING])))
+
 (deftest logging
   (testing "Appender ref and additivity"
-    (let [path (temp-file "unilog.config" "log")]
+    (let [tempfile (temp-file "unilog.config" "log")]
       (start-logging! {:level     :info
                        :console   false
                        :appenders [{:appender     :file
-                                    :file         (str path)
+                                    :file         (str tempfile)
                                     :encoder      :multipattern
-                                    :multipattern {:unilog (str "BASE_OVERRIDE " unilog.config/default-pattern)
+                                    :multipattern {:unilog                      (str "ROOT" unilog.config/default-pattern)
+                                                   :unilog.testns               (str "TESTNS " unilog.config/default-pattern)
                                                    :unilog.config-override-test "OVERRIDE_MARKER %c - %m%n%rEx{full,clojure}"}}]
                        :overrides {:unilog.config-override-test :error}})
 
-      (testing "logging from other ns"
+      (testing "logging from nsexample uses default logger"
+        (truncate tempfile)
+        (nsexample/info "info")
+        (is (not (str/includes? (slurp tempfile) "ROOT")))
+        (is (not (str/includes? (slurp tempfile) "TESTNS")))
+        (is (not (str/includes? (slurp tempfile) "OVERRIDE_MARKER"))))
+
+      (testing "logging from a configured ns"
+        (truncate tempfile)
         (testns/info "info")
-        (is (not (str/includes? (slurp path ) "OVERRIDE_MARKER")))
-        (is (str/includes? (slurp path) "BASE_OVERRIDE")))
+        (is (not (str/includes? (slurp tempfile) "OVERRIDE_MARKER")))
+        (is (str/includes? (slurp tempfile) "TESTNS")))
+
+      (testing "loggers prefixes are matched at the dot, substrings dont count"
+        ;; testns2 should log via root :unilog logger
+        (truncate tempfile)
+        (testns2/info "info")
+        (is (not (str/includes? (slurp tempfile) "TESTNS")))
+        (is (not (str/includes? (slurp tempfile) "OVERRIDE_MARKER")))
+        (is (str/includes? (slurp tempfile) "ROOT")))
 
       (testing "overrides still work"
+        (truncate tempfile)
         (info "info")
-        (is (not (str/includes? (slurp path ) "OVERRIDE_MARKER"))))
+        (is (not (str/includes? (slurp tempfile) "OVERRIDE_MARKER"))))
 
       (testing "custom logger pattern"
+        (truncate tempfile)
         (error "error")
-        (is (str/includes? (slurp path) "OVERRIDE_MARKER"))
+        (is (str/includes? (slurp tempfile) "OVERRIDE_MARKER"))
 
         (testing "exception filtering"
+          (truncate tempfile)
           (error (RuntimeException.) "ex")
-          (let [lines (to-lines path)]
+          (let [lines (to-lines tempfile)]
             (is (every? #(not (str/includes? % "clojure.")) lines))
 
             (testing "some parts of the stack are still preserved"

--- a/test/unilog/config_override_test.clj
+++ b/test/unilog/config_override_test.clj
@@ -1,0 +1,49 @@
+(ns unilog.config-override-test
+  (:require [unilog.config :refer [start-logging!]]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.logging :refer [debug info warn error]]
+            [unilog.testns :as testns]
+            [clojure.string :as str]))
+
+(defn- temp-file
+  "Temp file which gets deleted when the JVM stops"
+  [prefix suffix]
+  (doto (java.io.File/createTempFile prefix suffix)
+    (.deleteOnExit)))
+
+(defn- to-lines [path]
+  (->> (str/split (slurp path) #"\n")
+       (filter #(not (zero? (count %))))))
+
+(deftest logging
+  (testing "Appender ref and additivity"
+    (let [path (temp-file "unilog.config" "log")]
+      (start-logging! {:level     :info
+                       :console   false
+                       :appenders [{:appender     :file
+                                    :file         (str path)
+                                    :encoder      :multipattern
+                                    :multipattern {:unilog (str "BASE_OVERRIDE " unilog.config/default-pattern)
+                                                   :unilog.config-override-test "OVERRIDE_MARKER %c - %m%n%rEx{full,clojure}"}}]
+                       :overrides {:unilog.config-override-test :error}})
+
+      (testing "logging from other ns"
+        (testns/info "info")
+        (is (not (str/includes? (slurp path ) "OVERRIDE_MARKER")))
+        (is (str/includes? (slurp path) "BASE_OVERRIDE")))
+
+      (testing "overrides still work"
+        (info "info")
+        (is (not (str/includes? (slurp path ) "OVERRIDE_MARKER"))))
+
+      (testing "custom logger pattern"
+        (error "error")
+        (is (str/includes? (slurp path) "OVERRIDE_MARKER"))
+
+        (testing "exception filtering"
+          (error (RuntimeException.) "ex")
+          (let [lines (to-lines path)]
+            (is (every? #(not (str/includes? % "clojure.")) lines))
+
+            (testing "some parts of the stack are still preserved"
+              (is (some #(str/includes? % "unilog.config-override-test") lines)))))))))

--- a/test/unilog/testns.clj
+++ b/test/unilog/testns.clj
@@ -1,0 +1,13 @@
+(ns unilog.testns
+  "Test ns to check different loggers"
+  (:require [clojure.tools.logging :as log]))
+
+(defn info
+  ([msg] (log/info msg))
+  ([e msg] (log/info e msg)))
+(defn warn
+  ([msg] (log/warn msg))
+  ([e msg] (log/warn e msg)))
+(defn error
+  ([msg] (log/error msg))
+  ([e msg] (log/error e msg)))

--- a/test/unilog/testns2.clj
+++ b/test/unilog/testns2.clj
@@ -1,0 +1,13 @@
+(ns unilog.testns2
+  "Test ns to check different loggers"
+  (:require [clojure.tools.logging :as log]))
+
+(defn info
+  ([msg] (log/info msg))
+  ([e msg] (log/info e msg)))
+(defn warn
+  ([msg] (log/warn msg))
+  ([e msg] (log/warn e msg)))
+(defn error
+  ([msg] (log/error msg))
+  ([e msg] (log/error e msg)))


### PR DESCRIPTION
Particularly useful for applying exception filtering for a given class.
Allows this type of override for a given logger (`com.exoscale`):
```
{:level     :info
 :console   false
 :appenders [{:appender     :file
              :file         (str path)
              :encoder      :multipattern
              :multipattern {:com.exoscale "%c - %m%n%rEx{full,clojure}"}}]
 :overrides {:com.exoscale :debug}}
```
